### PR TITLE
Add writing guide

### DIFF
--- a/src/pages/writing.mdx
+++ b/src/pages/writing.mdx
@@ -1,0 +1,61 @@
+---
+title: Writing for the United Nations World Data Forum website
+description: A short guide on how to write for the World Data Forum website.
+---
+
+The United Nations World Data Forum website follows the [United Nations Editorial Manual](http://www.dgacm.org/editorialmanual/). This guide summarizes what you need to know when writing for the United Nations World Data Forum website.
+
+## Abbreviations and acronyms
+
+Use abbreviations sparingly. Do not assume that all users are familiar with abbreviations used by the statistical and data communities. These simple rules help make your writing easier to read and understand:
+
+- Do not use abbreviations in headings.
+- Do not use an abbreviation when it would occur only once.
+- Spell out an abbreviation when used for the first time and put the abbreviation in brackets, e.g. write _geographic information system (GIS)_ on first use and _GIS_ subsequently.
+- You can use acronyms as long as they are well established, e.g. there is no need to spell out UNDP or DESA, but if you refer to DFID it is probably better to spell it out on first occurrence.
+- Never abbreviate United Nations.
+
+## Special entities
+
+Always write _United Nations World Data Forum_. Do not use
+
+- _UN World Data Forum_,
+- _World Data Forum_,
+- _Data Forum_, or
+- just _Forum_.
+
+To refer to a specific year, write _2018 United Nations World Data Forum_.
+
+Always write _United Nations Statistical Commission_. Do not use
+
+- _UN Statistical Commission_,
+- _Statistical Commission_,
+- _Commission_,
+- _UNSC_, or
+- _Statcom_.
+
+Always write _United Nations Statistics Division_. Do not use
+
+- _UN Statistics Division_,
+- _Statistics Division_, or
+- _UNSD_.
+
+## Captialization
+
+In headings, capitalize the first word only. The only exception to this rule are terms that should always be capitalized, such as _Sustainable Development Goals_.
+
+Any other capitalizations should be used sparingly. Certain terms are capitalized when used in a specialized or restricted sense, the purpose of the capital being to point to the specialized or restricted sense.
+
+Here are some examples:
+
+- _Sustainable Development Goals_, _Sustainable Development Goal 13_ (or _Goal 13_) are always capitalized.
+- _2030 Agenda_ (not _Agenda 2030_), but _development agenda_.
+- _A group of experts_, but _Group of Experts on Gender Statistics_.
+- _National Statistical Offices_, but _official statistics_.
+- _Cape Town Action Plan_, but _geographic information systems_.
+
+You can find more examples [here](http://www.dgacm.org/editorialmanual/ed-guidelines/style/capitalization.htm).
+
+## Links
+
+For blog posts and profiles always include links to references you make. You can think of links in your writing as a leightweight bibliogrpahy that helps readers verify sources and claims you make. For example, if you refer to a specific report, such as "A World that Counts" link to it: [A World that Counts](http://www.undatarevolution.org/wp-content/uploads/2014/11/A-World-That-Counts.pdf).


### PR DESCRIPTION
This is my suggestion for our first iteration for the writing guide. Note that the United Nations Editorial Manual does not permit use of `UN` and always wants `United Nations` to be spelled out.

Regarding capitalization of headings: we can automate this with https://github.com/zeit/title. It's better to have consistent automated capitalization than inconsistent manual capitalization follwoing the official manual.